### PR TITLE
Document Bouncy Castle requirement for HTTPS certificate creation

### DIFF
--- a/docs/guides/medium/output_https.md
+++ b/docs/guides/medium/output_https.md
@@ -26,6 +26,8 @@ Enter text:
 Encrypted text: 797AD06F0FB6E1E6F4B17EB182670494D3EA259B24245847062CCA0C5D023F26
 ````
 
+> **Note:** When using newer versions of OpenAF together with Java 21 or later, generating the certificate might require the Bouncy Castle provider. You can install it by running `opack install bouncycastle` before executing the commands above.
+
 And then edit the HTTP plug, for example as 00.http.yaml:
 
 ````yaml


### PR DESCRIPTION
## Summary
- document that recent OpenAF with Java 21+ may require the Bouncy Castle provider when generating HTTPS certificates
- instruct users to install the provider with `opack install bouncycastle`

## Testing
- not run
